### PR TITLE
BREAKING CHANGE: use conventional export name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { Options } from './types'
 
 export const DEFAULT_EXTENSIONS = [/\.vert$/, /\.frag$/, /\.glsl$/]
 
-export function glslifyCompiler(options: Options = {}) {
+export function glslify(options: Options = {}) {
   const plugins: Plugin[] = []
   const transformFiles = options.transformFiles ?? true
   const transformLiterals = options.transformLiterals ?? true
@@ -37,4 +37,4 @@ export function glslifyCompiler(options: Options = {}) {
   return plugins
 }
 
-export default glslifyCompiler
+export default glslify


### PR DESCRIPTION
The current export name does not match the plugin name, I propose using the shorter name `glslify`.