### PR TITLE
Fix Vite peerDeps broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "vite": ">=^5.2.9"
+    "vite": "^5.2.9"
   },
   "dependencies": {
     "@rollup/pluginutils": "^4.1.1",


### PR DESCRIPTION
Fixes #14

Correct the `peerDependencies` version constraint for `vite` in `package.json`.

* Change the version constraint for `vite` from `>=^5.2.9` to `^5.2.9` in the `peerDependencies` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KusStar/vite-plugin-glslify/pull/15?shareId=911a9cde-98d4-4184-92ed-0db20a6586bb).