### PR TITLE
fix: support vite v6 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "vite": "^5.2.9"
+    "vite": "^5.2.9 || ^6"
   },
   "dependencies": {
     "@rollup/pluginutils": "^4.1.1",


### PR DESCRIPTION
## Summary

This PR updates the `peerDependencies` in `package.json` to support Vite v6.

- Before: `"vite": "^5.2.9"`
- After:  `"vite": "^5.2.9 || ^6"`

With this change, the plugin can be used with both Vite v5.2.9+ and v6.x.

## Related Issue

- #16

---

Thank you for your consideration.